### PR TITLE
Update content-fragments-variations.md

### DIFF
--- a/help/assets/content-fragments-variations.md
+++ b/help/assets/content-fragments-variations.md
@@ -357,7 +357,7 @@ When editing a variation you have access to the action for synchronizing the cur
 1. Open your content fragment in the fragment editor. Ensure that the **Master** has been edited.
 2. Select a specific variation, then the appropriate synchronization action from either:
 
-    * the **Actions** drop down selector - **Select current element with master** 
+    * the **Actions** drop down selector - **Sync current element with master** 
     * the toolbar of the full-screen editor - **Sync with master**
 
 3. Master and the variation will be shown side-by-side:


### PR DESCRIPTION
Fix typo in the name of selector option

Should be "Sync current element with master", but docs read "Select current element with master"

<img width="415" alt="Screen Shot 2020-01-13 at 11 21 35 AM" src="https://user-images.githubusercontent.com/19195468/72277233-33c58b80-35f7-11ea-81f3-f50b20d4b40f.png">
