### PR TITLE
Removing "/jcr:content/model" from the workflow model

### DIFF
--- a/help/sites-developing/workflows-program-interaction.md
+++ b/help/sites-developing/workflows-program-interaction.md
@@ -625,7 +625,7 @@ wfSession.terminateWorkflow(workflow);
   curl -d "model={id}&payloadType={type}&payload={payload}" http://localhost:4502/etc/workflow/instances
   
   # for example:
-  curl -u admin:admin -d "model=/var/workflow/models/request_for_activation/jcr:content/model&payloadType=JCR_PATH&payload=/content/we-retail/us/en/products" http://localhost:4502/etc/workflow/instances
+  curl -u admin:admin -d "model=/var/workflow/models/request_for_activation&payloadType=JCR_PATH&payload=/content/we-retail/us/en/products" http://localhost:4502/etc/workflow/instances
   ```
 
 * **Listing the instances**


### PR DESCRIPTION
Removing "/jcr:content/model" from the workflow model. Valid workflow model path is : /var/workflow/models/request_for_activation 

and working command is : 
curl -u admin:admin -d "model=/var/workflow/models/request_for_activation&payloadType=JCR_PATH&payload=/content/we-retail/us/en/products" http://localhost:4502/etc/workflow/instances