### PR TITLE
Fix typo

### DIFF
--- a/help/sites-developing/spa-overview.md
+++ b/help/sites-developing/spa-overview.md
@@ -15,7 +15,7 @@ discoiquuid: 897ff73f-15a5-484f-a3a2-616de8ac59dc
 
 Single page applications (SPAs) can offer compelling experiences for website users. Developers want to be able to build sites using SPA frameworks and authors want to seamlessly edit content within AEM for a site built using such frameworks.
 
-The SPA Editor offers a comprehensive solution for supporting SPAs within AEM. This page gives an overview of how SPA support is structured in AEM, how the SPA Editor works, and how the SPA framework and AEM keep in synch.
+The SPA Editor offers a comprehensive solution for supporting SPAs within AEM. This page gives an overview of how SPA support is structured in AEM, how the SPA Editor works, and how the SPA framework and AEM keep in sync.
 
 >[!NOTE]
 >


### PR DESCRIPTION
More common spelling is sync: https://www.merriam-webster.com/dictionary/sync