### PR TITLE
Update configure-analytics-forms-documents.md

### DIFF
--- a/help/forms/using/configure-analytics-forms-documents.md
+++ b/help/forms/using/configure-analytics-forms-documents.md
@@ -111,7 +111,7 @@ Perform the following steps to create a report suite.
 Cloud Service configuration is information about your Adobe Analytics account. The configuration enables Adobe Experience Manager (AEM) to connect to Adobe Analytics. Create a separate configuration for each Analytics account that you use.
 
 1. Log in to your AEM author instance as an administrator.
-1. In the top-left corner, click **Adobe Experience Manager** &gt; **Tools** ![tools](assets/tools.png)&gt; **Deployment** &gt; **Cloud Services**.
+1. In the top-left corner, click **Adobe Experience Manager** &gt; **Tools** ![tools](assets/tools.png)&gt; **Cloud Services** &gt; **Legacy Cloud Services**.
 1. Locate **Adobe Analytics** icon. Click **Show Configurations** and then proceed to click **[+]** to add new configuration.
 
    If you are a first-time user, click **Configure now**. 


### PR DESCRIPTION
The location of the legacy cloud services changed since AEM 6.4.
Also the first image under https://experienceleague.adobe.com/docs/experience-manager-64/forms/integrate-aem-forms-with-experience-cloud-solutions/configure-analytics-forms-documents.html?lang=en#creating-cloud-service-framework needs to be updated — I couldn't figure out how, attaching a link, please assist: https://drive.google.com/file/d/1g3RqlzHRzQlWZJ2uxekM4rgDWCEJ9HMP/view?usp=sharing